### PR TITLE
fix: support japanese typing

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -8,6 +8,7 @@ interface Props {
 
 export const ChatInput: FC<Props> = ({ onSend }) => {
   const [content, setContent] = useState<string>();
+  const [isTyping, setIsTyping] = useState<boolean>(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -31,7 +32,7 @@ export const ChatInput: FC<Props> = ({ onSend }) => {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (!isTyping && e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
     }
@@ -54,6 +55,8 @@ export const ChatInput: FC<Props> = ({ onSend }) => {
           placeholder="Type a message..."
           value={content}
           rows={1}
+          onCompositionStart={() => setIsTyping(true)}
+          onCompositionEnd={() => setIsTyping(false)}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
         />


### PR DESCRIPTION
# bug
The Japanese language has both kanji and hiragana, and the enter key is used to convert hiragana into kanji.
In the current implementation, `handleSend` is executed when the conversion is confirmed and starts sending messages.

# solution
When the conversion key is pressed, the message is not sent.

![スクリーンショット 2023-03-18 8 30 03](https://user-images.githubusercontent.com/40238917/226069406-94498d43-ae42-4c4d-9bb2-0e4d2c6a9126.png)
